### PR TITLE
adjust content-type for index.html

### DIFF
--- a/templates/copy-artifacts.template.yaml
+++ b/templates/copy-artifacts.template.yaml
@@ -47,7 +47,10 @@ Resources:
                       'Bucket': source_bucket,
                       'Key': key
                   }
-                  s3.copy_object(CopySource=copy_source, Bucket=dest_bucket, Key=key)
+                  if o.find("index.html")!=-1:
+                      s3.copy_object(CopySource=copy_source, Bucket=dest_bucket, Key=key,Metadata={"content-type": "text/html"})
+                  else:
+                      s3.copy_object(CopySource=copy_source, Bucket=dest_bucket, Key=key)
 
 
           def delete_objects(bucket):


### PR DESCRIPTION
issue #5

*Issue #5 , if available:*

*Description of changes:*

in the **CopyObjectsFunction** lambda function in the cloudformation template named **copy-artifacts.template.yaml**, add metadata to the index.html object in the form of content-type:text/html while copying.

Only do this if you find index.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
